### PR TITLE
Add MiSArch examples

### DIFF
--- a/.vitepress/components/DiagramList.vue
+++ b/.vitepress/components/DiagramList.vue
@@ -46,7 +46,10 @@ const diagrams: Record<string, () => Promise<any>> = {
     "Train Ticket": () => import("../../diagrams/Train-Ticket.yaml?raw"),
     DeathStarBench: () => import("../../diagrams/DeathStarBench-complete.yaml?raw"),
     "Online Boutique (expanded)": () => import("../../diagrams/Online-Boutique-expanded.yaml?raw"),
-    "Astronomy Shop": () => import("../../diagrams/Astronomy-Shop.yaml?raw")
+    "Astronomy Shop": () => import("../../diagrams/Astronomy-Shop.yaml?raw"),
+    MiSArch: () => import("../../diagrams/MiSArch.yaml?raw"),
+    "MiSArch (simplified)": () => import("../../diagrams/MiSArch-simplified.yaml?raw"),
+    "MiSArch (extended)": () => import("../../diagrams/MiSArch-extended.yaml?raw"),
 };
 
 async function openDiagram(name: string) {

--- a/diagrams/MiSArch-extended.yaml
+++ b/diagrams/MiSArch-extended.yaml
@@ -1,0 +1,699 @@
+Infrastructure:
+  template: Infrastructure
+RUSTGraphQLLibrary:
+  template: Library
+KotlinGraphQLLibrary:
+  template: Library
+NodeJsGraphQLLibrary:
+  template: Library
+keycloakJS:
+  template: Library
+mongoNestJSLibrary:
+  template: Library
+Frontend:
+  template: Frontend
+  interfaces:
+    Frontend_GraphQL_Required:
+      template: GraphQL_Required
+      relations:
+        - to: Gateway_GraphQL_Provided
+          template: Calls
+      name: ""
+    Frontend_OAUTH_Required:
+      template: OAUTH_Required
+      relations:
+        - to: Keycloak_OAUTH
+          template: Calls
+      name: ""
+  relations:
+    - to: Infrastructure        
+      template: Hosted_on 
+    - to: keycloakJS
+      template: Includes
+Gateway:  
+  template: Microservice  
+  interfaces: 
+    Gateway_GraphQL_Provided: 
+      template: GraphQL_Provided   
+      name: ""
+    Gateway_GraphQL_Required:         
+      template: GraphQL_Required
+      relations:
+        - to: User_GraphQL_Provided_Gateway
+          template: Calls
+        - to: Address_GraphQL_Provided_Gateway
+          template: Calls
+        - to: Invoice_GraphQL_Provided_Gateway
+          template: Calls
+        - to: Discount_GraphQL_Provided_Gateway
+          template: Calls
+        - to: Wishlist_GraphQL_Provided_Gateway
+          template: Calls
+        - to: ShoppingCart_GraphQL_Provided_Gateway
+          template: Calls
+        - to: Return_GraphQL_Provided_Gateway
+          template: Calls
+        - to: Review_GraphQL_Provided_Gateway
+          template: Calls
+        - to: Catalog_GraphQL_Provided_Gateway
+          template: Calls
+        - to: Shipment_GraphQL_Provided_Gateway
+          template: Calls
+        - to: Payment_GraphQL_Provided_Gateway
+          template: Calls
+        - to: Order_GraphQL_Provided_Gateway
+          template: Calls
+        - to: Inventory_GraphQL_Provided_Gateway
+          template: Calls
+        - to: Tax_GraphQL_Provided_Gateway
+          template: Calls
+        - to: Media_GraphQL_Provided_Gateway
+          template: Calls
+      name: ""
+    Gateway_OAUTH_Required:
+      template: OAUTH_Required
+      relations:
+        - to: Keycloak_OAUTH
+          template: Calls
+      name: ""
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+Notification:
+  template: Microservice
+  interfaces:
+    Notification_notification/notification/create:
+      template: Messaging_Subscribe
+      name: ""
+    Notification_user/user/created:
+      template: Messaging_Subscribe
+      name: ""
+    Notification_GraphQL_Provided_Gateway:
+      template: GraphQL_Provided
+      name: ""
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+Keycloak:
+  template: Microservice
+  interfaces:
+    Keycloak_user/user/create:
+      template: Messaging_Publish
+      name: ""
+    Keycloak_OAUTH:
+      template: OAUTH_Provided
+      name: ""
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+User:
+  template: Microservice
+  interfaces:
+    User_user/user/create:
+      template: Messaging_Subscribe
+      relations:
+        - to: Keycloak_user/user/create
+          template: Event
+      name: ""
+    User_user/user/created:
+      template: Messaging_Publish
+      name: ""
+    User_GraphQL_Provided_Gateway:
+      template: GraphQL_Provided
+      name: ""
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+Address:
+  template: Microservice
+  interfaces:
+    Address_user/user/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: User_user/user/created
+          template: Event
+      name: ""
+    Address_address/user-address/created:
+      template: Messaging_Publish
+      name: ""
+    Address_address/vendor-address/created:
+      template: Messaging_Publish
+      name: ""
+    Address_address/user-address/archived:
+      template: Messaging_Publish
+      name: ""
+    Address_GraphQL_Provided_Gateway:
+      template: GraphQL_Provided
+      name: ""
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+Invoice:
+  template: Microservice
+  interfaces:
+    Invoice_discount/order/validation-succeeded:
+      template: Messaging_Subscribe
+      relations:
+        - to: Discount_discount/order/validation-succeeded
+          template: Event
+      name: ""
+    Invoice_address/vendor-address/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Address_address/vendor-address/created
+          template: Event
+      name: ""
+    Invoice_address/user-address/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Address_address/user-address/created
+          template: Event
+      name: ""
+    Invoice_address/user-address/archived:
+      template: Messaging_Subscribe
+      relations:
+        - to: Address_address/user-address/archived
+          template: Event
+      name: ""
+    Invoice_user/user/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: User_user/user/created
+          template: Event
+      name: ""
+    Invoice_invoice/invoice/created:
+      template: Messaging_Publish
+      name: ""
+    Invoice_GraphQL_Provided_Gateway:
+      template: GraphQL_Provided
+      name: ""
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: RUSTGraphQLLibrary
+      template: Includes
+Discount:
+  template: Microservice
+  interfaces:
+    Discount_inventory/product-item/reservation-succeeded:
+      template: Messaging_Subscribe
+      relations:
+        - to: Inventory_inventory/product-item/reservation-succeeded
+          template: Event
+      name: ""
+    Discount_user/user/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: User_user/user/created
+          template: Event
+      name: ""
+    Discount_catalog/category/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Catalog_catalog/category/created
+          template: Event
+      name: ""
+    Discount_catalog/product/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Catalog_catalog/product/created
+          template: Event
+      name: ""
+    Discount_catalog/product-variant/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Catalog_catalog/product-variant/created
+          template: Event
+      name: ""
+    Discount_discount/discount/created:
+      template: Messaging_Publish
+      name: ""
+    Discount_discount/discount/updated:
+      template: Messaging_Publish
+      name: ""
+    Discount_discount/coupon/created:
+      template: Messaging_Publish
+      name: ""
+    Discount_discount/coupon/updated:
+      template: Messaging_Publish
+      name: ""
+    Discount_discount/order/validation-succeeded:
+      template: Messaging_Publish
+      name: ""
+    Discount_discount/order/validation-failed:
+      template: Messaging_Publish
+      name: ""
+    Discount_GraphQL_Provided:
+      template: GraphQL_Provided
+      name: ""
+    Discount_GraphQL_Provided_Gateway:
+      template: GraphQL_Provided
+      name: ""
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+Wishlist:
+  template: Microservice
+  interfaces:
+    Wishlist_user/user/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: User_user/user/created
+          template: Event
+      name: ""
+    Wishlist_catalog/product-variant/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Catalog_catalog/product-variant/created
+          template: Event
+      name: ""
+    Wishlist_GraphQL_Provided_Gateway:
+      template: GraphQL_Provided
+      name: ""
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: RUSTGraphQLLibrary
+      template: Includes
+ShoppingCart:
+  template: Microservice
+  interfaces:
+    ShoppingCart_user/user/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: User_user/user/created
+          template: Event
+      name: ""
+    ShoppingCart_catalog/product-variant/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Catalog_catalog/product-variant/created
+          template: Event
+      name: ""
+    ShoppingCart_order/order/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Order_order/order/created
+          template: Event
+      name: ""
+    ShoppingCart_GraphQL_Provided_Gateway:
+      template: GraphQL_Provided
+      name: ""
+    ShoppingCart_GraphQL_Provided:
+      template: GraphQL_Provided
+      name: ""
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: RUSTGraphQLLibrary
+      template: Includes
+Return:
+  template: Microservice
+  interfaces:
+    Return_shipment/shipment/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Shipment_shipment/shipment/created
+          template: Event
+      name: ""
+    Return_shipment/shipment/status-updated:
+      template: Messaging_Subscribe
+      relations:
+        - to: Shipment_shipment/shipment/status-updated
+          template: Event
+      name: ""
+    Return_order/order/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Order_order/order/created
+          template: Event
+      name: ""
+    Return_catalog/product-variant-version/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Catalog_catalog/product-variant-version/created
+          template: Event
+      name: ""
+    Return_return/return/created:
+      template: Messaging_Publish
+      name: ""
+    Return_GraphQL_Provided_Gateway:
+      template: GraphQL_Provided
+      name: ""
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+Review:
+  template: Microservice
+  interfaces:
+    Review_user/user/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: User_user/user/created
+          template: Event
+      name: ""
+    Review_catalog/product-variant/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Catalog_catalog/product-variant/created
+          template: Event
+      name: ""
+    Review_GraphQL_Provided_Gateway:
+      template: GraphQL_Provided
+      name: ""
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: RUSTGraphQLLibrary
+      template: Includes
+Catalog:
+  template: Microservice
+  interfaces:
+    Catalog_tax/tax-rate/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Tax_tax/tax-rate/created
+          template: Event
+      name: ""
+    Catalog_media/media/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Media_media/media/created
+          template: Event
+      name: ""
+    Catalog_catalog/product/created:
+      template: Messaging_Publish
+      name: ""
+    Catalog_catalog/product-variant/created:
+      template: Messaging_Publish
+      name: ""
+    Catalog_catalog/product-variant-version/created:
+      template: Messaging_Publish
+      name: ""
+    Catalog_catalog/category/created:
+      template: Messaging_Publish
+      name: ""
+    Catalog_catalog/product/updated:
+      template: Messaging_Publish
+      name: ""
+    Catalog_catalog/product-variant/updated:
+      template: Messaging_Publish
+      name: ""
+    Catalog_GraphQL_Provided_Gateway:
+      template: GraphQL_Provided
+      name: ""
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+Shipment:
+  template: Microservice
+  interfaces:
+    Shipment_payment/payment/payment-enabled:
+      template: Messaging_Subscribe
+      relations:
+        - to: Payment_payment/payment/payment-enabled
+          template: Event
+      name: ""
+    Shipment_address/user-address/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Address_address/user-address/created
+          template: Event
+      name: ""
+    Shipment_address/vendor-address/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Address_address/vendor-address/created
+          template: Event
+      name: ""
+    Shipment_catalog/product-variant-version/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Catalog_catalog/product-variant-version/created
+          template: Event
+      name: ""
+    Shipment_return/return/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Return_return/return/created
+          template: Event
+      name: ""
+    Shipment_shipment/shipment/created:
+      template: Messaging_Publish
+      name: ""
+    Shipment_shipment/shipment/creation-failed:
+      template: Messaging_Publish
+      name: ""
+    Shipment_shipment/shipment/status-updated:
+      template: Messaging_Publish
+      name: ""
+    Shipment_shipment/shipment-method/created:
+      template: Messaging_Publish
+      name: ""
+    Shipment_shipment/shipment-method/archived:
+      template: Messaging_Publish
+      name: ""
+    Shipment_GraphQL_Provided:
+      template: GraphQL_Provided
+      name: ""
+    Shipment_GraphQL_Provided_Gateway:
+      template: GraphQL_Provided
+      name: ""
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+Payment:
+  template: Microservice
+  interfaces:
+    Payment_user/user/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: User_user/user/created
+          template: Event
+      name: ""
+    Payment_discount/order/validation-succeeded:
+      template: Messaging_Subscribe
+      relations:
+        - to: Discount_discount/order/validation-succeeded
+          template: Event
+      name: ""
+    Payment_payment/payment/payment-enabled:
+      template: Messaging_Publish
+      name: ""
+    Payment_payment/payment/payment-processed:
+      template: Messaging_Publish
+      name: ""
+    Payment_payment/payment/payment-failed:
+      template: Messaging_Publish
+      name: ""
+    Payment_GraphQL_Provided_Gateway:
+      template: GraphQL_Provided
+      name: ""
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: NodeJsGraphQLLibrary
+      template: Includes
+    - to: mongoNestJSLibrary
+      template: Includes
+Order:
+  template: Microservice
+  interfaces:
+    Order_catalog/product-variant-version/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Catalog_catalog/product-variant-version/created
+          template: Event
+      name: ""
+    Order_discount/coupon/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Discount_discount/coupon/created
+          template: Event
+      name: ""
+    Order_tax/tax-rate-version/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Tax_tax/tax-rate-version/created
+          template: Event
+      name: ""
+    Order_shipment/shipment-method/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Shipment_shipment/shipment-method/created
+          template: Event
+      name: ""
+    Order_user/user/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: User_user/user/created
+          template: Event
+      name: ""
+    Order_address/user-address/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Address_address/user-address/created
+          template: Event
+      name: ""
+    Order_address/user-address/archived:
+      template: Messaging_Subscribe
+      relations:
+        - to: Address_address/user-address/archived
+          template: Event
+      name: ""
+    Order_shipment/shipment/creation-failed:
+      template: Messaging_Subscribe
+      relations:
+        - to: Shipment_shipment/shipment/creation-failed
+          template: Event
+      name: ""
+    Order_order/order/created:
+      template: Messaging_Publish
+      name: ""
+    Order_order/order-compensation/created:
+      template: Messaging_Publish
+      name: ""
+    Order_GraphQL_Required_Discount:
+      template: GraphQL_Required
+      relations:
+        - to: Discount_GraphQL_Provided
+          template: Calls
+      name: ""
+    Order_GraphQL_Required_Inventory:
+      template: GraphQL_Required
+      relations:
+        - to: Inventory_GraphQL_Provided
+          template: Calls
+      name: ""
+    Order_GraphQL_Required_Shipment:
+      template: GraphQL_Required
+      relations:
+        - to: Shipment_GraphQL_Provided
+          template: Calls
+      name: ""
+    Order_GraphQL_Required_ShoppingCart:
+      template: GraphQL_Required
+      relations:
+        - to: ShoppingCart_GraphQL_Provided
+          template: Calls
+      name: ""
+    Order_GraphQL_Provided_Gateway:
+      template: GraphQL_Provided
+      name: ""
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: RUSTGraphQLLibrary
+      template: Includes
+Inventory:
+  template: Microservice
+  interfaces:
+    Inventory_catalog/product-variant/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Catalog_catalog/product-variant/created
+          template: Event
+      name: ""
+    Inventory_order/order/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Order_order/order/created
+          template: Event
+      name: ""
+    Inventory_payment/payment/payment-enabled:
+      template: Messaging_Subscribe
+      relations:
+        - to: Payment_payment/payment/payment-enabled
+          template: Event
+      name: ""
+    Inventory_payment/payment/payment-failed:
+      template: Messaging_Subscribe
+      relations:
+        - to: Payment_payment/payment/payment-failed
+          template: Event
+      name: ""
+    Inventory_shipment/shipment/status-updated:
+      template: Messaging_Subscribe
+      relations:
+        - to: Shipment_shipment/shipment/status-updated
+          template: Event
+      name: ""
+    Inventory_shipment/shipment/created:
+      template: Messaging_Subscribe
+      relations:
+        - to: Shipment_shipment/shipment/created
+          template: Event
+      name: ""
+    Inventory_discount/order/validation-failed:
+      template: Messaging_Subscribe
+      relations:
+        - to: Discount_discount/order/validation-failed
+          template: Event
+      name: ""
+    Inventory_inventory/product/created:
+      template: Messaging_Publish
+      name: ""
+    Inventory_inventory/product-item/reservation-succeeded:
+      template: Messaging_Publish
+      name: ""
+    Inventory_inventory/product-item/reservation-failed:
+      template: Messaging_Publish
+      name: ""
+    Inventory_GraphQL_Provided:
+      template: GraphQL_Provided
+      name: ""
+    Inventory_GraphQL_Provided_Gateway:
+      template: GraphQL_Provided
+      name: ""
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: NodeJsGraphQLLibrary
+      template: Includes
+    - to: mongoNestJSLibrary
+      template: Includes
+Tax:
+  template: Microservice
+  interfaces:
+    Tax_tax/tax-rate/created:
+      template: Messaging_Publish
+      name: ""
+    Tax_tax/tax-rate-version/created:
+      template: Messaging_Publish
+      name: ""
+    Tax_GraphQL_Provided_Gateway:
+      template: GraphQL_Provided
+      name: ""
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+Media:
+  template: Microservice
+  interfaces:
+    Media_media/media/created:
+      template: Messaging_Publish
+      name: ""
+    Media_GraphQL_Provided_Gateway:
+      template: GraphQL_Provided
+      name: ""
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: RUSTGraphQLLibrary
+      template: Includes

--- a/diagrams/MiSArch-simplified.yaml
+++ b/diagrams/MiSArch-simplified.yaml
@@ -1,0 +1,263 @@
+Infrastructure:
+  template: Infrastructure
+RUSTGraphQLLibrary:
+  template: Library
+KotlinGraphQLLibrary:
+  template: Library
+NodeJsGraphQLLibrary:
+  template: Library
+keycloakJS:
+  template: Library
+mongoNestJSLibrary:
+  template: Library
+Frontend:
+  template: Frontend
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: keycloakJS
+      template: Includes
+    - to: Gateway
+      template: Calls
+    - to: Keycloak
+      template: Calls
+Gateway:
+  template: Microservice
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: User
+      template: Calls
+    - to: Address
+      template: Calls
+    - to: Invoice
+      template: Calls
+    - to: Discount
+      template: Calls
+    - to: Wishlist
+      template: Calls
+    - to: ShoppingCart
+      template: Calls
+    - to: Return
+      template: Calls
+    - to: Review
+      template: Calls
+    - to: Catalog
+      template: Calls
+    - to: Shipment
+      template: Calls
+    - to: Payment
+      template: Calls
+    - to: Order
+      template: Calls
+    - to: Inventory
+      template: Calls
+    - to: Tax
+      template: Calls
+    - to: Media
+      template: Calls
+    - to: Keycloak
+      template: Calls
+Notification:
+  template: Microservice
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+Keycloak:
+  template: Microservice
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+User:
+  template: Microservice
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+    - to: Keycloak
+      template: Event
+Address:
+  template: Microservice
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+    - to: User
+      template: Event
+Invoice:
+  template: Microservice
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: RUSTGraphQLLibrary
+      template: Includes
+    - to: Discount
+      template: Event
+    - to: Address
+      template: Event
+    - to: User
+      template: Event
+Discount:
+  template: Microservice
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+    - to: Inventory
+      template: Event
+    - to: User
+      template: Event
+    - to: Catalog
+      template: Event
+Wishlist:
+  template: Microservice
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: RUSTGraphQLLibrary
+      template: Includes
+    - to: User
+      template: Event
+    - to: Catalog
+      template: Event
+ShoppingCart:
+  template: Microservice
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: RUSTGraphQLLibrary
+      template: Includes
+    - to: User
+      template: Event
+    - to: Catalog
+      template: Event
+    - to: Order
+      template: Event
+Return:
+  template: Microservice
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+    - to: Shipment
+      template: Event
+    - to: Order
+      template: Event
+    - to: Catalog
+      template: Event
+Review:
+  template: Microservice
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: RUSTGraphQLLibrary
+      template: Includes
+    - to: User
+      template: Event
+    - to: Catalog
+      template: Event
+Catalog:
+  template: Microservice
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+    - to: Tax
+      template: Event
+    - to: Media
+      template: Event
+Shipment:
+  template: Microservice
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+    - to: Payment
+      template: Event
+    - to: Address
+      template: Event
+    - to: Catalog
+      template: Event
+    - to: Return
+      template: Event
+Payment:
+  template: Microservice
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: NodeJsGraphQLLibrary
+      template: Includes
+    - to: mongoNestJSLibrary
+      template: Includes
+    - to: User
+      template: Event
+    - to: Discount
+      template: Event
+Order:
+  template: Microservice
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: RUSTGraphQLLibrary
+      template: Includes
+    - to: Catalog
+      template: Event
+    - to: Discount
+      template: Event
+    - to: Tax
+      template: Event
+    - to: Shipment
+      template: Event
+    - to: User
+      template: Event
+    - to: Address
+      template: Event
+    - to: Discount
+      template: Calls
+    - to: Inventory
+      template: Calls
+    - to: Shipment
+      template: Calls
+    - to: ShoppingCart
+      template: Calls
+Inventory:
+  template: Microservice
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: NodeJsGraphQLLibrary
+      template: Includes
+    - to: mongoNestJSLibrary
+      template: Includes
+    - to: Catalog
+      template: Event
+    - to: Order
+      template: Event
+    - to: Payment
+      template: Event
+    - to: Shipment
+      template: Event
+    - to: Discount
+      template: Event
+Tax:
+  template: Microservice
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+Media:
+  template: Microservice
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: RUSTGraphQLLibrary
+      template: Includes

--- a/diagrams/MiSArch.yaml
+++ b/diagrams/MiSArch.yaml
@@ -1,0 +1,482 @@
+Infrastructure:
+  template: Infrastructure
+RUSTGraphQLLibrary:
+  template: Library
+KotlinGraphQLLibrary:
+  template: Library
+NodeJsGraphQLLibrary:
+  template: Library
+keycloakJS:
+  template: Library
+mongoNestJSLibrary:
+  template: Library
+Frontend:
+  template: Frontend
+  interfaces:
+    Frontend_GraphQL_Required:
+      template: GraphQL_Required
+      relations:
+        - to: Gateway_GraphQL_Provided
+          template: Calls
+      name: GraphQL (Required)
+    Frontend_OAUTH_Required:
+      template: OAUTH_Required
+      relations:
+        - to: Keycloak_OAUTH_Provided
+          template: Calls
+      name: OAUTH (Required)
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: keycloakJS
+      template: Includes
+Gateway:
+  template: Microservice
+  interfaces:
+    Gateway_GraphQL_Provided:
+      template: GraphQL_Provided
+      name: GraphQL
+      relations: []
+    Gateway_GraphQL_Required:
+      template: GraphQL_Required
+      relations:
+        - to: User_GraphQL_Provided
+          template: Calls
+        - to: Address_GraphQL_Provided
+          template: Calls
+        - to: Invoice_GraphQL_Provided
+          template: Calls
+        - to: Discount_GraphQL_Provided
+          template: Calls
+        - to: Wishlist_GraphQL_Provided
+          template: Calls
+        - to: ShoppingCart_GraphQL_Provided
+          template: Calls
+        - to: Return_GraphQL_Provided
+          template: Calls
+        - to: Review_GraphQL_Provided
+          template: Calls
+        - to: Catalog_GraphQL_Provided
+          template: Calls
+        - to: Shipment_GraphQL_Provided
+          template: Calls
+        - to: Payment_GraphQL_Provided
+          template: Calls
+        - to: Order_GraphQL_Provided
+          template: Calls
+        - to: Inventory_GraphQL_Provided
+          template: Calls
+        - to: Tax_GraphQL_Provided
+          template: Calls
+        - to: Media_GraphQL_Provided
+          template: Calls
+      name: GraphQL (Required)
+    Gateway_OAUTH_Required:
+      template: OAUTH_Required
+      relations:
+        - to: Keycloak_OAUTH_Provided
+          template: Calls
+      name: OAUTH (Required)
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+Notification:
+  template: Microservice
+  interfaces:
+    Notification_Messaging_Subscribe:
+      template: Messaging_Subscribe
+      name: Subscribe
+      relations: []
+    Notification_GraphQL_Provided:
+      template: GraphQL_Provided
+      name: GraphQL
+      relations: []
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+Keycloak:
+  template: Microservice
+  interfaces:
+    Keycloak_Messaging_Publish:
+      template: Messaging_Publish
+      name: Publish
+      relations: []
+    Keycloak_OAUTH_Provided:
+      template: OAUTH_Provided
+      name: OAUTH
+      relations: []
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+User:
+  template: Microservice
+  interfaces:
+    User_Messaging_Subscribe:
+      template: Messaging_Subscribe
+      relations:
+        - to: Keycloak_Messaging_Publish
+          template: Event
+      name: Subscribe
+    User_Messaging_Publish:
+      template: Messaging_Publish
+      name: Publish
+      relations: []
+    User_GraphQL_Provided:
+      template: GraphQL_Provided
+      name: GraphQL
+      relations: []
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+Address:
+  template: Microservice
+  interfaces:
+    Address_Messaging_Subscribe:
+      template: Messaging_Subscribe
+      relations:
+        - to: User_Messaging_Publish
+          template: Event
+      name: Subscribe
+    Address_Messaging_Publish:
+      template: Messaging_Publish
+      name: Publish
+      relations: []
+    Address_GraphQL_Provided:
+      template: GraphQL_Provided
+      name: GraphQL
+      relations: []
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+Invoice:
+  template: Microservice
+  interfaces:
+    Invoice_Messaging_Subscribe:
+      template: Messaging_Subscribe
+      relations:
+        - to: Discount_Messaging_Publish
+          template: Event
+        - to: Address_Messaging_Publish
+          template: Event
+        - to: User_Messaging_Publish
+          template: Event
+      name: Subscribe
+    Invoice_Messaging_Publish:
+      template: Messaging_Publish
+      name: Publish
+      relations: []
+    Invoice_GraphQL_Provided:
+      template: GraphQL_Provided
+      name: GraphQL
+      relations: []
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: RUSTGraphQLLibrary
+      template: Includes
+Discount:
+  template: Microservice
+  interfaces:
+    Discount_Messaging_Subscribe:
+      template: Messaging_Subscribe
+      relations:
+        - to: Inventory_Messaging_Publish
+          template: Event
+        - to: User_Messaging_Publish
+          template: Event
+        - to: Catalog_Messaging_Publish
+          template: Event
+      name: Subscribe
+    Discount_Messaging_Publish:
+      template: Messaging_Publish
+      name: Publish
+      relations: []
+    Discount_GraphQL_Provided:
+      template: GraphQL_Provided
+      name: GraphQL
+      relations: []
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+Wishlist:
+  template: Microservice
+  interfaces:
+    Wishlist_Messaging_Subscribe:
+      template: Messaging_Subscribe
+      relations:
+        - to: User_Messaging_Publish
+          template: Event
+        - to: Catalog_Messaging_Publish
+          template: Event
+      name: Subscribe
+    Wishlist_GraphQL_Provided:
+      template: GraphQL_Provided
+      name: GraphQL
+      relations: []
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: RUSTGraphQLLibrary
+      template: Includes
+ShoppingCart:
+  template: Microservice
+  interfaces:
+    ShoppingCart_Messaging_Subscribe:
+      template: Messaging_Subscribe
+      relations:
+        - to: User_Messaging_Publish
+          template: Event
+        - to: Catalog_Messaging_Publish
+          template: Event
+        - to: Order_Messaging_Publish
+          template: Event
+      name: Subscribe
+    ShoppingCart_GraphQL_Provided:
+      template: GraphQL_Provided
+      name: GraphQL
+      relations: []
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: RUSTGraphQLLibrary
+      template: Includes
+Return:
+  template: Microservice
+  interfaces:
+    Return_Messaging_Subscribe:
+      template: Messaging_Subscribe
+      relations:
+        - to: Shipment_Messaging_Publish
+          template: Event
+        - to: Order_Messaging_Publish
+          template: Event
+        - to: Catalog_Messaging_Publish
+          template: Event
+      name: Subscribe
+    Return_Messaging_Publish:
+      template: Messaging_Publish
+      name: Publish
+      relations: []
+    Return_GraphQL_Provided:
+      template: GraphQL_Provided
+      name: GraphQL
+      relations: []
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+Review:
+  template: Microservice
+  interfaces:
+    Review_Messaging_Subscribe:
+      template: Messaging_Subscribe
+      relations:
+        - to: User_Messaging_Publish
+          template: Event
+        - to: Catalog_Messaging_Publish
+          template: Event
+      name: Subscribe
+    Review_GraphQL_Provided:
+      template: GraphQL_Provided
+      name: GraphQL
+      relations: []
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: RUSTGraphQLLibrary
+      template: Includes
+Catalog:
+  template: Microservice
+  interfaces:
+    Catalog_Messaging_Subscribe:
+      template: Messaging_Subscribe
+      relations:
+        - to: Tax_Messaging_Publish
+          template: Event
+        - to: Media_Messaging_Publish
+          template: Event
+      name: Subscribe
+    Catalog_Messaging_Publish:
+      template: Messaging_Publish
+      name: Publish
+      relations: []
+    Catalog_GraphQL_Provided:
+      template: GraphQL_Provided
+      name: GraphQL
+      relations: []
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+Shipment:
+  template: Microservice
+  interfaces:
+    Shipment_Messaging_Subscribe:
+      template: Messaging_Subscribe
+      relations:
+        - to: Payment_Messaging_Publish
+          template: Event
+        - to: Address_Messaging_Publish
+          template: Event
+        - to: Catalog_Messaging_Publish
+          template: Event
+        - to: Return_Messaging_Publish
+          template: Event
+      name: Subscribe
+    Shipment_Messaging_Publish:
+      template: Messaging_Publish
+      name: Publish
+      relations: []
+    Shipment_GraphQL_Provided:
+      template: GraphQL_Provided
+      name: GraphQL
+      relations: []
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+Payment:
+  template: Microservice
+  interfaces:
+    Payment_Messaging_Subscribe:
+      template: Messaging_Subscribe
+      relations:
+        - to: User_Messaging_Publish
+          template: Event
+        - to: Discount_Messaging_Publish
+          template: Event
+      name: Subscribe
+    Payment_Messaging_Publish:
+      template: Messaging_Publish
+      name: Publish
+      relations: []
+    Payment_GraphQL_Provided:
+      template: GraphQL_Provided
+      name: GraphQL
+      relations: []
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: NodeJsGraphQLLibrary
+      template: Includes
+    - to: mongoNestJSLibrary
+      template: Includes
+Order:
+  template: Microservice
+  interfaces:
+    Order_Messaging_Subscribe:
+      template: Messaging_Subscribe
+      relations:
+        - to: Catalog_Messaging_Publish
+          template: Event
+        - to: Discount_Messaging_Publish
+          template: Event
+        - to: Tax_Messaging_Publish
+          template: Event
+        - to: Shipment_Messaging_Publish
+          template: Event
+        - to: User_Messaging_Publish
+          template: Event
+        - to: Address_Messaging_Publish
+          template: Event
+      name: Subscribe
+    Order_Messaging_Publish:
+      template: Messaging_Publish
+      name: Publish
+      relations: []
+    Order_GraphQL_Required:
+      template: GraphQL_Required
+      relations:
+        - to: Discount_GraphQL_Provided
+          template: Calls
+        - to: Inventory_GraphQL_Provided
+          template: Calls
+        - to: Shipment_GraphQL_Provided
+          template: Calls
+        - to: ShoppingCart_GraphQL_Provided
+          template: Calls
+      name: GraphQL (Required)
+    Order_GraphQL_Provided:
+      template: GraphQL_Provided
+      name: GraphQL
+      relations: []
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: RUSTGraphQLLibrary
+      template: Includes
+Inventory:
+  template: Microservice
+  interfaces:
+    Inventory_Messaging_Subscribe:
+      template: Messaging_Subscribe
+      relations:
+        - to: Catalog_Messaging_Publish
+          template: Event
+        - to: Order_Messaging_Publish
+          template: Event
+        - to: Payment_Messaging_Publish
+          template: Event
+        - to: Shipment_Messaging_Publish
+          template: Event
+        - to: Discount_Messaging_Publish
+          template: Event
+      name: Subscribe
+    Inventory_Messaging_Publish:
+      template: Messaging_Publish
+      name: Publish
+      relations: []
+    Inventory_GraphQL_Provided:
+      template: GraphQL_Provided
+      name: GraphQL
+      relations: []
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: NodeJsGraphQLLibrary
+      template: Includes
+    - to: mongoNestJSLibrary
+      template: Includes
+Tax:
+  template: Microservice
+  interfaces:
+    Tax_Messaging_Publish:
+      template: Messaging_Publish
+      name: Publish
+      relations: []
+    Tax_GraphQL_Provided:
+      template: GraphQL_Provided
+      name: GraphQL
+      relations: []
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: KotlinGraphQLLibrary
+      template: Includes
+Media:
+  template: Microservice
+  interfaces:
+    Media_Messaging_Publish:
+      template: Messaging_Publish
+      name: Publish
+      relations: []
+    Media_GraphQL_Provided:
+      template: GraphQL_Provided
+      name: GraphQL
+      relations: []
+  relations:
+    - to: Infrastructure
+      template: Hosted_on
+    - to: RUSTGraphQLLibrary
+      template: Includes


### PR DESCRIPTION
Adds the MiSArch architecture with in three variants
- regular: interfaces: GraphQL / GraphQL (required), OAuth, OAuth (required), Publish, Subscribe
- simplified: removed all interfaces, relations directly on components
- extended: messaging interfaces per topic, in some cases multiple GraphQL interfaces